### PR TITLE
Add terragrunt hook to implement Vault port-forwarding

### DIFF
--- a/cm-vault/cm-config/main.tf
+++ b/cm-vault/cm-config/main.tf
@@ -1,20 +1,20 @@
 terraform {
   required_providers {
     kubernetes = {
-        source  = "hashicorp/kubernetes"
-        version = "~> 2.11.0"
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.11.0"
     }
   }
 }
 
 provider "kubernetes" {
-  config_path = var.kubeconfig_path
+  config_path = pathexpand(var.kubeconfig_path)
 }
 
 // vault-token is used to connect vault
 resource "kubernetes_secret_v1" "vault-token" {
   metadata {
-    name = "vault-token"
+    name      = "vault-token"
     namespace = "cert-manager"
   }
   data = {
@@ -48,15 +48,15 @@ resource "kubernetes_manifest" "vault-issuer" {
 resource "kubernetes_manifest" "demo-app-vault-cert" {
   manifest = {
     "apiVersion" = "cert-manager.io/v1"
-    "kind" = "Certificate"
+    "kind"       = "Certificate"
     metadata = {
-      "name" = "demo-app-vault-cert"
+      "name"      = "demo-app-vault-cert"
       "namespace" = "default"
     }
     "spec" = {
       "commonName" = "demo-app.cert-manager.io"
       "secretName" = "demo-app-tls"
-      "dnsNames" = ["demo-app.cert-manager.io"]
+      "dnsNames"   = ["demo-app.cert-manager.io"]
       "issuerRef" = {
         "name" = kubernetes_manifest.vault-issuer.manifest.metadata.name
         "kind" = kubernetes_manifest.vault-issuer.manifest.kind

--- a/cm-vault/cm-install/main.tf
+++ b/cm-vault/cm-install/main.tf
@@ -9,7 +9,7 @@ terraform {
 
 provider "helm" {
   kubernetes {
-    config_path = var.kubeconfig_path
+    config_path = pathexpand(var.kubeconfig_path)
   }
 }
 

--- a/cm-vault/vault-config/_shared/start_vault_service.sh
+++ b/cm-vault/vault-config/_shared/start_vault_service.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+NODE_PORT=30200
+CONTAINER_PORT=8200
+SERVICE="service/vault"
+NAMESPACE="vault"
+
+echo "Executing 'kubectl port-forward' to establish the connection to Vault installed in Kubernetes"
+
+echo -en "kubectl port-forward $SERVICE $NODE_PORT:$CONTAINER_PORT -n $NAMESPACE\n disown" > run_service.sh && chmod +x run_service.sh
+nohup bash run_service.sh </dev/null >/dev/null 2>&1 &
+
+# sleep was to give it a chance to finish establishing the connection before terragrunt/terraform starts running
+echo "Sleeping for 10s while waiting for connection to be established"
+sleep 10s

--- a/cm-vault/vault-config/_shared/stop_vault_service.sh
+++ b/cm-vault/vault-config/_shared/stop_vault_service.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SERVICE="service/vault"
+
+kill -9 $(ps -aux |grep $SERVICE |grep -v grep | awk '{print $2}')
+
+rm -f run_service.sh

--- a/cm-vault/vault-config/main.tf
+++ b/cm-vault/vault-config/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     vault = {
-      source = "hashicorp/vault"
+      source  = "hashicorp/vault"
       version = "~> 3.5.0"
     }
   }
@@ -13,9 +13,9 @@ provider "vault" {
 }
 
 resource "vault_mount" "pki" {
-  path                      = "pki"
-  type                      = "pki"
-  max_lease_ttl_seconds     = 31536000 # 1 year
+  path                  = "pki"
+  type                  = "pki"
+  max_lease_ttl_seconds = 31536000 # 1 year
 }
 
 resource "vault_pki_secret_backend_role" "role" {

--- a/cm-vault/vault-config/terragrunt.hcl
+++ b/cm-vault/vault-config/terragrunt.hcl
@@ -3,3 +3,16 @@ dependency "vault-install" {
 
   skip_outputs = "true"
 }
+
+terraform {
+  before_hook "before_hook" {
+    commands     = ["apply", "plan", "destroy"]
+    execute      = ["${get_parent_terragrunt_dir()}/_shared/start_vault_service.sh"]
+  }
+
+  after_hook "after_hook" {
+    commands     = ["apply", "plan", "destroy"]
+    execute      = ["${get_parent_terragrunt_dir()}/_shared/stop_vault_service.sh"]
+    run_on_error = true
+  }
+}

--- a/cm-vault/vault-install/main.tf
+++ b/cm-vault/vault-install/main.tf
@@ -9,39 +9,38 @@ terraform {
 
 provider "helm" {
   kubernetes {
-    config_path = var.kubeconfig_path
+    config_path = pathexpand(var.kubeconfig_path)
   }
 }
 
 # deploy vault
 resource "helm_release" "vault" {
-  name       = "vault"
-  repository = "https://helm.releases.hashicorp.com"
-  chart      = "vault"
+  name             = "vault"
+  repository       = "https://helm.releases.hashicorp.com"
+  chart            = "vault"
   namespace        = "vault"
   create_namespace = true
   version          = "0.20.1" # The version of Vault is 1.10.3
+  wait             = true
 
   set {
     # This installs a single unsealed Vault server in the insecure dev mode with a memory storage backend.
     name  = "server.dev.enabled"
     value = "true"
   }
-
-  set {
-    name = "server.service.type"
-    value = "NodePort"
-  }
-
-  set {
-    name = "server.service.nodePort"
-    value = "30200"
-  }
 }
 
-# wait for port-forwarding successfully
-resource "time_sleep" "wait_30_seconds" {
-  depends_on = [helm_release.vault]
-
-  create_duration = "30s"
+# Wait for Vault StatefulSet to become Ready before proceeding. Helm release
+# seems to not be configurable in such a way as to wait for a StatefulSet to be
+# ready https://github.com/helm/helm/pull/10920
+resource "null_resource" "wait_for_vault" {
+  provisioner "local-exec" {
+   environment = {
+    KUBECONFIG = pathexpand(var.kubeconfig_path)
+   }
+   command = "kubectl wait --for condition=Ready=true pod/vault-0 -n vault --timeout 300s"
+  }
+  depends_on = [
+    helm_release.vault
+  ]
 }


### PR DESCRIPTION
Signed-off-by: lonelyCZ <531187475@qq.com>

Fixes #10 

This pr is to add terragrunt hook to implement Vault port-forwarding.

I have tested it in my `kind` cluster and `kubeadm` cluster that worked fine. But it need more tests in different env.