### PR TITLE
Create a single variables file for cert-manager + Vault workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,13 +7,6 @@
 *.tfstate
 *.tfstate.*
 
-# Exclude all .tfvars files, which are likely to contain sentitive data, such as
-# password, private keys, and other secrets. These should not be part of version 
-# control as they are data points which are potentially sensitive and subject 
-# to change depending on the environment.
-#
-*.tfvars
-
 # Ignore override files as they are usually used to override resources locally and so
 # are not checked in
 override.tf

--- a/cm-vault/README.md
+++ b/cm-vault/README.md
@@ -37,11 +37,21 @@ To use Kubernetes Provider to configure Cert-Manager. By default, it create a `C
 
 ## Usage Steps
 
-Execute `terragrunt run-all init` to init providers of all modules.
+### 1. Execute `terragrunt run-all init` to init providers of all modules.
 
-Execute `terragrunt run-all apply` to deploy all modules.
+### 2. Configurate custom variable.
 
-Execute `terragrunt run-all destroy` to clean test environment.
+You can configurate custom variables in `common.tfvars`.
+
+```
+# Path to the kubeconfig file to use for connecting kubernetes cluster. Default is "~/.kube/config"
+kubeconfig_path="~/.kube/config"
+......
+```
+
+### 3. Execute `terragrunt run-all apply` to deploy all modules.
+
+### 4. Execute `terragrunt run-all destroy` to clean test environment.
 
 ### Note
 If you want to run it in [Kind](https://kind.sigs.k8s.io/) cluster, you need to [create extra port mappings](https://kind.sigs.k8s.io/docs/user/configuration/#extra-port-mappings) to `vault-install` module to port forward.

--- a/cm-vault/cm-config/terragrunt.hcl
+++ b/cm-vault/cm-config/terragrunt.hcl
@@ -1,18 +1,35 @@
 dependency "vault-install" {
-    config_path = "../vault-install"
+  config_path = "../vault-install"
 
-    skip_outputs = "true"
+  skip_outputs = "true"
 }
 
 dependency "cm-install" {
-    config_path = "../cm-install"
+  config_path = "../cm-install"
 
-    skip_outputs = "true"
+  skip_outputs = "true"
 }
 
 
 dependency "vault-config" {
-    config_path = "../vault-config"
+  config_path = "../vault-config"
 
-    skip_outputs = "true"
+  skip_outputs = "true"
+}
+
+terraform {
+  extra_arguments "common_vars" {
+    commands = [
+      "apply",
+      "plan",
+      "import",
+      "push",
+      "refresh",
+      "destroy"
+    ]
+
+    arguments = [
+      "-var-file=${get_parent_terragrunt_dir()}/../common.tfvars"
+    ]
+  }
 }

--- a/cm-vault/cm-install/terragrunt.hcl
+++ b/cm-vault/cm-install/terragrunt.hcl
@@ -1,0 +1,16 @@
+terraform {
+  extra_arguments "common_vars" {
+    commands = [
+      "apply",
+      "plan",
+      "import",
+      "push",
+      "refresh",
+      "destroy"
+    ]
+
+    arguments = [
+      "-var-file=${get_parent_terragrunt_dir()}/../common.tfvars"
+    ]
+  }
+}

--- a/cm-vault/common.tfvars
+++ b/cm-vault/common.tfvars
@@ -1,0 +1,3 @@
+
+# Path to the kubeconfig file to use for connecting kubernetes cluster. Default is "~/.kube/config"
+kubeconfig_path="~/.kube/config"

--- a/cm-vault/vault-config/terragrunt.hcl
+++ b/cm-vault/vault-config/terragrunt.hcl
@@ -1,5 +1,5 @@
 dependency "vault-install" {
-    config_path = "../vault-install"
+  config_path = "../vault-install"
 
-    skip_outputs = "true"
+  skip_outputs = "true"
 }

--- a/cm-vault/vault-install/terragrunt.hcl
+++ b/cm-vault/vault-install/terragrunt.hcl
@@ -1,0 +1,16 @@
+terraform {
+  extra_arguments "common_vars" {
+    commands = [
+      "apply",
+      "plan",
+      "import",
+      "push",
+      "refresh",
+      "destroy"
+    ]
+
+    arguments = [
+      "-var-file=${get_parent_terragrunt_dir()}/../common.tfvars"
+    ]
+  }
+}


### PR DESCRIPTION
Signed-off-by: lonelyCZ <531187475@qq.com>

Fixes #7 

We can configure `kubeconfig_path` in `cm-vault/common.tfvars` to apply to all modules.