### PR TITLE
Wait for cert-manager resources to become ready

### DIFF
--- a/cm-vault/cm-config/main.tf
+++ b/cm-vault/cm-config/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.11.0"
+      version = "~> 2.12.1"
     }
   }
 }
@@ -43,6 +43,19 @@ resource "kubernetes_manifest" "vault-issuer" {
       }
     }
   }
+
+  wait {
+    condition {
+      type = "Ready"
+      status = "True"
+    }
+  }
+
+  timeouts {
+    create = "1m"
+    update = "1m"
+    delete = "30s"
+  }
 }
 
 resource "kubernetes_manifest" "demo-app-vault-cert" {
@@ -62,5 +75,18 @@ resource "kubernetes_manifest" "demo-app-vault-cert" {
         "kind" = kubernetes_manifest.vault-issuer.manifest.kind
       }
     }
+  }
+
+  wait {
+    condition {
+      type = "Ready"
+      status = "True"
+    }
+  }
+
+  timeouts {
+    create = "1m"
+    update = "1m"
+    delete = "30s"
   }
 }


### PR DESCRIPTION
Signed-off-by: lonelyCZ <531187475@qq.com>

Fixes #15 

The result is shown below

```
kubernetes_manifest.vault-issuer: Still creating... [9m30s elapsed]
kubernetes_manifest.vault-issuer: Still creating... [9m40s elapsed]
kubernetes_manifest.vault-issuer: Still creating... [9m50s elapsed]
kubernetes_manifest.vault-issuer: Still creating... [10m0s elapsed]
╷
│ Warning: Value for undeclared variable
│
│ The root module does not declare a variable named "cm_version" but a value
│ was found in file
│ "/root/lonelyCZ/testing-addons/cm-vault/cm-config/../common.tfvars". If you
│ meant to use this value, add a "variable" block to the configuration.
│
│ To silence these warnings, use TF_VAR_... environment variables to provide
│ certain "global" settings to all configurations in your organization. To
│ reduce the verbosity of these warnings, use the -compact-warnings option.
╵
╷
│ Warning: Value for undeclared variable
│
│ The root module does not declare a variable named "vault_version" but a
│ value was found in file
│ "/root/lonelyCZ/testing-addons/cm-vault/cm-config/../common.tfvars". If you
│ meant to use this value, add a "variable" block to the configuration.
│
│ To silence these warnings, use TF_VAR_... environment variables to provide
│ certain "global" settings to all configurations in your organization. To
│ reduce the verbosity of these warnings, use the -compact-warnings option.
╵
╷
│ Error: Operation timed out
│
│   with kubernetes_manifest.vault-issuer,
│   on main.tf line 26, in resource "kubernetes_manifest" "vault-issuer":
│   26: resource "kubernetes_manifest" "vault-issuer" {
│
│ Terraform timed out waiting on the operation to complete
```